### PR TITLE
Panel Fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,19 @@ to be displayed:
 
 ```kotlin
 class MyActivity: Activity() {
-    private val myParameters = listOf(TEST_PARAMETER)
+    private val myParameters = arrayOf(TEST_PARAMETER)
 
     fun showControlPanel() {
         startSharedPreferencePanel(myParameters)
     }
 }
+```
+
+Alternatively, you can use the Shared Preference panel as a fragment by using
+`SharedPreferencesPanelFragment`
+
+```kotlin
+val panel = SharedPreferencesPanelFragment(myParameters)
 ```
 
 The panel uses the `SharedPreferencesConfigProvider` to change
@@ -170,12 +177,19 @@ of your parameters:
 
 ```kotlin
 class MyActivity: Activity() {
-    private val myParameters = listOf(TEST_PARAMETER)
+    private val myParameters = arrayOf(TEST_PARAMETER)
 
     fun showControlPanel() {
         startFirebasePanel(myParameters)
     }
 }
+```
+
+Alternatively, you can use the Firebase panel as a fragment by using
+`FirebasePanelFragment`
+
+```kotlin
+val panel = FirebasePanelFragment(myParameters)
 ```
 
 Dependency Injection

--- a/panel-android-sharedpreferences/src/main/java/switchgear/panel/android/sharedpreferences/SharedPreferencesPanelActivity.kt
+++ b/panel-android-sharedpreferences/src/main/java/switchgear/panel/android/sharedpreferences/SharedPreferencesPanelActivity.kt
@@ -2,60 +2,27 @@ package switchgear.panel.android.sharedpreferences
 
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.xwray.groupie.GroupAdapter
-import com.xwray.groupie.kotlinandroidextensions.ViewHolder
-import inkapplications.switchgear.panel.android.sharedpreferences.R
+import androidx.fragment.app.Fragment
 import switchgear.Parameter
-import switchgear.provider.sharedpreferences.SharedPreferencesConfigProvider
-
-private const val PARAMETERS = "extra.parameters"
+import switchgear.panel.android.PanelActivity
+import switchgear.panel.android.startPanelActivity
 
 /**
  * A list of overridable configuration parameters in SharedPreferences.
  *
- * This allows you to view and override all of the specified configuration
- * parameters using the SharedPreferences provider.
+ * This wraps the [SharedPreferencesPanelFragment] in an activity for ease of use.
+ * Call [Context.startSharedPreferencePanel] to start this activity correctly.
  */
-open class SharedPreferencesPanelActivity: AppCompatActivity() {
-    private val parameters get() = intent.getSerializableExtra(PARAMETERS) as Array<Parameter<Any>>
-
-    private lateinit var controlPanel: RecyclerView
-    private lateinit var preferenceProvider: SharedPreferencesConfigProvider
-    private lateinit var itemFactory: ItemFactory
-    private val adapter = GroupAdapter<ViewHolder>()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        setContentView(R.layout.sharedpreference_panel)
-        controlPanel = findViewById(R.id.control_panel)
-        controlPanel.layoutManager = LinearLayoutManager(this)
-        controlPanel.adapter = adapter
-        preferenceProvider = SharedPreferencesConfigProvider(this)
-        itemFactory = ItemFactory(preferenceProvider, ::refreshItems)
-    }
-
-    override fun onStart() {
-        super.onStart()
-        refreshItems()
-    }
-
-    fun refreshItems() {
-        val items = parameters.map { itemFactory.create(it) }
-
-        adapter.update(items)
+open class SharedPreferencesPanelActivity: PanelActivity() {
+    override fun createPanel(parameters: Array<Parameter<Any>>): Fragment {
+        return SharedPreferencesPanelFragment(parameters)
     }
 }
 
-fun Context.startSharedPreferencePanel(parameters: List<Parameter<Any>>) {
-    Intent(this, SharedPreferencesPanelActivity::class.java)
-        .apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            putExtra(PARAMETERS, parameters.toTypedArray())
-        }
-        .run(::startActivity)
+
+/**
+ * Start the Shared Preference Panel as an Activity.
+ */
+fun Context.startSharedPreferencePanel(parameters: Array<Parameter<Any>>, intentActions: Intent.() -> Unit = {}) {
+    startPanelActivity(SharedPreferencesPanelActivity::class, parameters, intentActions)
 }

--- a/panel-android-sharedpreferences/src/main/java/switchgear/panel/android/sharedpreferences/SharedPreferencesPanelFragment.kt
+++ b/panel-android-sharedpreferences/src/main/java/switchgear/panel/android/sharedpreferences/SharedPreferencesPanelFragment.kt
@@ -1,0 +1,55 @@
+package switchgear.panel.android.sharedpreferences
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.kotlinandroidextensions.ViewHolder
+import inkapplications.switchgear.panel.android.sharedpreferences.R
+import switchgear.Parameter
+import switchgear.panel.android.PanelFragment
+import switchgear.provider.sharedpreferences.SharedPreferencesConfigProvider
+
+/**
+ * A list of overridable configuration parameters in SharedPreferences.
+ *
+ * This allows you to view and override all of the specified configuration
+ * parameters using the SharedPreferences provider.
+ */
+class SharedPreferencesPanelFragment: PanelFragment {
+    private val controlPanel: RecyclerView? get() = view?.findViewById(R.id.control_panel)
+    private val preferenceProvider: SharedPreferencesConfigProvider by lazy { SharedPreferencesConfigProvider(context!!) }
+    private val itemFactory: ItemFactory by lazy { ItemFactory(preferenceProvider, ::refreshItems) }
+    private val adapter = GroupAdapter<ViewHolder>()
+
+    /** Android Constructor. Do not call directly. */
+    constructor(): super()
+
+    /**
+     * Create a fragment with parameters to display.
+     *
+     * You should always create the Fragment with this constructor.
+     *
+     * @param parameters The configuration parameters to be displayed.
+     */
+    constructor(parameters: Array<Parameter<Any>>): super(parameters)
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.sharedpreference_panel, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        controlPanel!!.adapter = adapter
+        refreshItems()
+    }
+
+    fun refreshItems() {
+        val items = parameters.map { itemFactory.create(it) }
+
+        adapter.update(items)
+    }
+}

--- a/panel-android-sharedpreferences/src/main/res/layout/sharedpreference_panel.xml
+++ b/panel-android-sharedpreferences/src/main/res/layout/sharedpreference_panel.xml
@@ -36,6 +36,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:listitem="@layout/item_switch"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:nestedScrollingEnabled="false"
             app:layout_constraintTop_toBottomOf="@id/firebase_panel_title"
             />

--- a/panel-android/src/main/java/switchgear/panel/android/PanelActivity.kt
+++ b/panel-android/src/main/java/switchgear/panel/android/PanelActivity.kt
@@ -1,0 +1,43 @@
+package switchgear.panel.android
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import switchgear.Parameter
+import kotlin.reflect.KClass
+
+private const val PARAMETERS = "extra.parameters"
+
+/**
+ * Panel with parameter extras and a single displayed fragment.
+ *
+ * This is to make it easier to display panels as both fragments or activities.
+ * Call [Context.startPanelActivity] to start this activity.
+ */
+abstract class PanelActivity: AppCompatActivity() {
+    private val parameters get() = intent.getSerializableExtra(PARAMETERS) as Array<Parameter<Any>>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        supportFragmentManager.beginTransaction()
+            .replace(android.R.id.content, createPanel(parameters))
+            .commit()
+    }
+
+    abstract fun createPanel(parameters: Array<Parameter<Any>>): Fragment
+}
+
+fun Context.startPanelActivity(
+    activity: KClass<out PanelActivity>,
+    parameters: Array<Parameter<Any>>,
+    intentActions: Intent.() -> Unit
+) {
+    Intent(this, activity.java)
+        .apply {
+            putExtra(PARAMETERS, parameters)
+            intentActions(this)
+        }
+        .run(::startActivity)
+}

--- a/panel-android/src/main/java/switchgear/panel/android/PanelFragment.kt
+++ b/panel-android/src/main/java/switchgear/panel/android/PanelFragment.kt
@@ -1,0 +1,20 @@
+package switchgear.panel.android
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import switchgear.Parameter
+
+private const val PARAMETERS = "arguments.parameters"
+
+/**
+ * A Fragment constructed with parameters.
+ */
+abstract class PanelFragment(): Fragment() {
+    protected val parameters get() = (arguments?.get(PARAMETERS) as? Array<Parameter<Any>>?) ?: arrayOf()
+
+    constructor(parameters: Array<Parameter<Any>>): this() {
+        arguments = Bundle().apply {
+            putSerializable(PARAMETERS, parameters)
+        }
+    }
+}

--- a/panel-firebase/src/main/java/switchgear/panel/firebase/FirebasePanelActivity.kt
+++ b/panel-firebase/src/main/java/switchgear/panel/firebase/FirebasePanelActivity.kt
@@ -2,50 +2,26 @@ package switchgear.panel.firebase
 
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.google.firebase.remoteconfig.FirebaseRemoteConfig
-import com.xwray.groupie.GroupAdapter
-import com.xwray.groupie.kotlinandroidextensions.ViewHolder
-import inkapplications.switchgear.panel.firebase.R
+import androidx.fragment.app.Fragment
 import switchgear.Parameter
-import switchgear.provider.firebase.RemoteConfigProvider
+import switchgear.panel.android.PanelActivity
+import switchgear.panel.android.startPanelActivity
 
-private const val PARAMETERS = "extra.parameters"
-
-class FirebasePanelActivity: AppCompatActivity() {
-    private val parameters get() = intent.getSerializableExtra(PARAMETERS) as Array<Parameter<Any>>
-
-    private lateinit var items: RecyclerView
-    private val adapter = GroupAdapter<ViewHolder>()
-    private lateinit var preferenceProvider: RemoteConfigProvider
-    private lateinit var itemFactory: ItemFactory
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        setContentView(R.layout.firebase_panel)
-        items = findViewById(R.id.firebase_panel_items)
-        items.layoutManager = LinearLayoutManager(this)
-        items.adapter = adapter
-        preferenceProvider = RemoteConfigProvider(FirebaseRemoteConfig.getInstance())
-        itemFactory = ItemFactory(preferenceProvider)
-    }
-
-    override fun onStart() {
-        super.onStart()
-
-        val items = parameters.map { itemFactory.create(it) }.run(adapter::update)
+/**
+ * Panel to display the current status of Firebase Remote config's flags.
+ *
+ * This wraps the [FirebasePanelFragment] in an activity for ease of use.
+ * Call [Context.startFirebasePanel] to start this activity correctly.
+ */
+class FirebasePanelActivity: PanelActivity() {
+    override fun createPanel(parameters: Array<Parameter<Any>>): Fragment {
+        return FirebasePanelFragment(parameters)
     }
 }
 
-fun Context.startFirebasePanel(parameters: List<Parameter<Any>>) {
-    Intent(this, FirebasePanelActivity::class.java)
-        .apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            putExtra(PARAMETERS, parameters.toTypedArray())
-        }
-        .run(::startActivity)
+/**
+ * Start the Firebase Panel as an Activity.
+ */
+fun Context.startFirebasePanel(parameters: Array<Parameter<Any>>, intentActions: Intent.() -> Unit = {}) {
+    startPanelActivity(FirebasePanelActivity::class, parameters, intentActions)
 }

--- a/panel-firebase/src/main/java/switchgear/panel/firebase/FirebasePanelFragment.kt
+++ b/panel-firebase/src/main/java/switchgear/panel/firebase/FirebasePanelFragment.kt
@@ -1,0 +1,50 @@
+package switchgear.panel.firebase
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.kotlinandroidextensions.ViewHolder
+import inkapplications.switchgear.panel.firebase.R
+import switchgear.Parameter
+import switchgear.panel.android.PanelFragment
+import switchgear.provider.firebase.RemoteConfigProvider
+
+/**
+ * Panel to display the current status of Firebase Remote config's flags.
+ *
+ * Pass parameters to load into the constructor of this class to display
+ * properly.
+ */
+class FirebasePanelFragment: PanelFragment {
+    private val items: RecyclerView? get() = view?.findViewById(R.id.firebase_panel_items)
+    private val adapter = GroupAdapter<ViewHolder>()
+    private val preferenceProvider: RemoteConfigProvider by lazy { RemoteConfigProvider(FirebaseRemoteConfig.getInstance()) }
+    private val itemFactory: ItemFactory by lazy { ItemFactory(preferenceProvider) }
+
+    /** Android Constructor. Do not call directly. */
+    constructor(): super()
+
+    /**
+     * Create a fragment with parameters to display.
+     *
+     * You should always create the Fragment with this constructor.
+     *
+     * @param parameters The configuration parameters to be displayed.
+     */
+    constructor(parameters: Array<Parameter<Any>>): super(parameters)
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.firebase_panel, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        items!!.adapter = adapter
+        parameters.map(itemFactory::create).run(adapter::update)
+    }
+}

--- a/panel-firebase/src/main/res/layout/firebase_panel.xml
+++ b/panel-firebase/src/main/res/layout/firebase_panel.xml
@@ -33,6 +33,7 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/firebase_panel_items"
             android:layout_width="match_parent"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@id/firebase_panel_title"
             android:nestedScrollingEnabled="false"


### PR DESCRIPTION
Creates fragments for both of the android panels and abstracts some of the logic away to make them simpler.

You can now Use either a fragment or an activity for the panels.

Fixes #2 